### PR TITLE
Bump megaparsec dependency (bump 0.1.2)

### DIFF
--- a/git-config.cabal
+++ b/git-config.cabal
@@ -1,11 +1,13 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0aca7139a8c14002852a9afd277d50d4d9a76b6740a53a8bff57f37d8d70c611
+-- hash: 0f49020a8cdb5c1fe3c4e47e6cb7ac3faa25db36208c7e09265b20c9769c645b
 
 name:           git-config
-version:        0.1.1
+version:        0.1.2
 synopsis:       A simple parser for Git configuration files
 description:    git-config is a simple 'megaparsec' parser for Git configuration files.
                 .
@@ -32,8 +34,6 @@ copyright:      2018 Fernando Freire
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
-
 extra-source-files:
     README.md
 
@@ -48,7 +48,7 @@ library
   ghc-options: -Wall -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
       base >=4.7 && <5
-    , megaparsec
+    , megaparsec >=7 && <9
     , text
     , unordered-containers
   exposed-modules:
@@ -64,6 +64,8 @@ test-suite git-config-test
       test
   default-extensions: OverloadedStrings
   ghc-options: -Wall -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      tasty-discover:tasty-discover >=4.2.1 && <4.3
   build-depends:
       base >=4.7 && <5
     , git-config

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: git-config
-version: '0.1.1'
+version: '0.1.2'
 synopsis: A simple parser for Git configuration files
 description: |
   git-config is a simple 'megaparsec' parser for Git configuration files.
@@ -46,13 +46,14 @@ library:
   source-dirs: src
   dependencies:
     - unordered-containers
-    - megaparsec
+    - megaparsec >=7 && < 9
     - text
   exposed-modules:
     - Text.GitConfig.Parser
 
 tests:
   git-config-test:
+    build-tools: tasty-discover:tasty-discover ^>=4.2.1
     main: Tasty.hs
     source-dirs: test
     ghc-options:

--- a/src/Text/GitConfig/Parser.hs
+++ b/src/Text/GitConfig/Parser.hs
@@ -50,15 +50,15 @@ import qualified Data.HashMap.Strict        as M
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Void                  (Void)
-import           Text.Megaparsec            (ParseError, Parsec, Token, between,
-                                             eof, many, parse, sepBy, some,
+import           Text.Megaparsec            (ParseErrorBundle, Parsec, between,
+                                             eof, many, parse, satisfy, sepBy, some,
                                              (<?>), (<|>))
 import           Text.Megaparsec.Char       (alphaNumChar, char, eol,
-                                             letterChar, printChar, satisfy,
+                                             letterChar, printChar,
                                              space1)
 import qualified Text.Megaparsec.Char.Lexer as Lexer
 
-type GitConfigError = ParseError (Token Text) Void
+type GitConfigError = ParseErrorBundle Text Void
 type Parser = Parsec Void Text
 
 data Section = Section [Text] (HashMap Text Text)


### PR DESCRIPTION
This also fixes `cabal test` by adding `tasty-discover` as a buildtool dependency

Something I don't cover here is updating `stack.yaml` for the newer megaparsec dep