### PR TITLE
Bump megaparsec dependency (bump 0.1.3)

### DIFF
--- a/git-config.cabal
+++ b/git-config.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0f49020a8cdb5c1fe3c4e47e6cb7ac3faa25db36208c7e09265b20c9769c645b
+-- hash: c8635f17733d63dd6af8855a6a8ad55dffb4644076ccbf17df337f48bd608e9d
 
 name:           git-config
 version:        0.1.2
@@ -48,7 +48,7 @@ library
   ghc-options: -Wall -fno-warn-partial-type-signatures -fno-warn-name-shadowing -fwarn-tabs -fwarn-unused-imports -fwarn-missing-signatures -fwarn-incomplete-patterns
   build-depends:
       base >=4.7 && <5
-    , megaparsec >=7 && <9
+    , megaparsec >=7 && <10
     , text
     , unordered-containers
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: git-config
-version: '0.1.2'
+version: '0.1.3'
 synopsis: A simple parser for Git configuration files
 description: |
   git-config is a simple 'megaparsec' parser for Git configuration files.
@@ -46,7 +46,7 @@ library:
   source-dirs: src
   dependencies:
     - unordered-containers
-    - megaparsec >=7 && < 9
+    - megaparsec >=7 && < 10
     - text
   exposed-modules:
     - Text.GitConfig.Parser


### PR DESCRIPTION
I'm back with [another bump to the megaparsec dependency bound](https://github.com/dogonthehorizon/git-config/pull/6)